### PR TITLE
 feat:FamiliarDefendingAction Add defending action

### DIFF
--- a/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
+++ b/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
@@ -124,15 +124,25 @@ public class FamiliarBattles
             {
                 var attack = await firstAttacker.Attack();
                 var defend = await secondAttacker.Defend(attack);
-                secondAttacker.Health -= defend;
+                secondAttacker.Health -= defend.DamageTaken;
+                
                 var criticalHit = attack.CriticalHit == true ? "***" : "";
-
                 embed.WithFields().AddField(
                     $"{criticalHit}{firstAttackerUser.Username}'s {firstAttacker.Name} attacks {secondAttackerUser.Username}'s {secondAttacker.Name} with {attack.AbilityName} for {defend} damage!{criticalHit}",
                     $"{secondAttackerUser.Username}'s {secondAttacker.Name} has {secondAttacker.Health} health remaining.");
                 await reply.ModifyAsync(
                     new Action<MessageProperties>(props => { props.Embed = embed.Build(); }));
                 var winner = CheckWinner(context, firstAttacker, secondAttackerUser, secondAttacker, secondAttackerUser);
+                if (winner) return winner;
+                
+                if (defend.IsReflecting)
+                {
+                    firstAttacker.Health -= defend.DamageReflected;
+                    embed.WithFields().AddField(
+                        $"{firstAttackerUser.Username}'s {firstAttacker.Name} reflects {defend.DamageReflected} damage back to {secondAttackerUser.Username}'s {secondAttacker.Name} using its {defend.DamageReflectedMessage}!",
+                        $"{secondAttackerUser.Username}'s {secondAttacker.Name} has {secondAttacker.Health} health remaining.");
+                }
+                winner = CheckWinner(context, secondAttacker, firstAttackerUser, firstAttacker, firstAttackerUser);
                 return winner;
             }
             else
@@ -205,7 +215,5 @@ public class FamiliarBattles
 
             return completedTask == tcs.Task ? await tcs.Task : null;
         }
-        
     }
-    
 }

--- a/AFamiliarWorld/Bot/Commands/FamiliarManagement.cs
+++ b/AFamiliarWorld/Bot/Commands/FamiliarManagement.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using AFamiliarWorld.Bot.Familiars;
+using AFamiliarWorld.Bot.Familiars.StarterFamiliars;
 using Discord.Commands;
 using Newtonsoft.Json;
 

--- a/AFamiliarWorld/Bot/Commands/Models/FamiliarAttackingAction.cs
+++ b/AFamiliarWorld/Bot/Commands/Models/FamiliarAttackingAction.cs
@@ -1,0 +1,10 @@
+namespace AFamiliarWorld.Bot.Commands.Models;
+
+public class FamiliarAttackingAction
+{
+    public int Damage { get; set; }
+    public DamageType DamageType { get; set; }
+    public string AbilityName { get; set; }
+    public bool CriticalHit { get; set; } = false;
+    public List<StatusCondition>? StatusConditions { get; set; }
+}

--- a/AFamiliarWorld/Bot/Commands/Models/FamiliarDefendingAction.cs
+++ b/AFamiliarWorld/Bot/Commands/Models/FamiliarDefendingAction.cs
@@ -1,0 +1,9 @@
+﻿namespace AFamiliarWorld.Bot.Commands.Models;
+
+public class FamiliarDefendingAction
+{
+    public int DamageTaken { get; set; }
+    public int DamageReflected { get; set; }
+    public string? DamageReflectedMessage { get; set; }
+    public bool IsReflecting { get; set; } = false;
+}

--- a/AFamiliarWorld/Bot/Familiars/Batnana.cs
+++ b/AFamiliarWorld/Bot/Familiars/Batnana.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Batnana:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public Batnana()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             BatnanaMonch
         };
@@ -30,16 +30,16 @@ public class Batnana:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> BatnanaMonch()
+    public async Task<FamiliarAttackingAction> BatnanaMonch()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Batnana Monch";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class Batnana:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/BookMimic.cs
+++ b/AFamiliarWorld/Bot/Familiars/BookMimic.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class BookMimic:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public BookMimic()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             BookBite
         };
@@ -30,17 +30,17 @@ public class BookMimic:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
     
-    public async Task<FamiliarAction> BookBite()
+    public async Task<FamiliarAttackingAction> BookBite()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "BookBite";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -52,28 +52,30 @@ public class BookMimic:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/Clockroach.cs
+++ b/AFamiliarWorld/Bot/Familiars/Clockroach.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Clockroach:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public Clockroach()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             ClockroachAttack
         };
@@ -30,16 +30,16 @@ public class Clockroach:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> ClockroachAttack()
+    public async Task<FamiliarAttackingAction> ClockroachAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Clockroach Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class Clockroach:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/Familiar.cs
+++ b/AFamiliarWorld/Bot/Familiars/Familiar.cs
@@ -114,13 +114,13 @@ public class Familiar
         return embed;
     }
 
-    public virtual async Task<FamiliarAction> Attack()
+    public virtual async Task<FamiliarAttackingAction> Attack()
     {
         return null;
     }
 
-    public virtual async Task<int> Defend(FamiliarAction action)
+    public virtual async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        return -1;
+        return null;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/LandShork.cs
+++ b/AFamiliarWorld/Bot/Familiars/LandShork.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class LandShork:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public LandShork()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             LandShorkMonch
         };
@@ -30,16 +30,16 @@ public class LandShork:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> LandShorkMonch()
+    public async Task<FamiliarAttackingAction> LandShorkMonch()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "LandShork Monch";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class LandShork:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/NoodleCrab.cs
+++ b/AFamiliarWorld/Bot/Familiars/NoodleCrab.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class NoodleCrab:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public NoodleCrab()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             NoodleCrabPinch
         };
@@ -30,16 +30,16 @@ public class NoodleCrab:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> NoodleCrabPinch()
+    public async Task<FamiliarAttackingAction> NoodleCrabPinch()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Noodle Crab Pinch";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class NoodleCrab:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/Pebblewyrm.cs
+++ b/AFamiliarWorld/Bot/Familiars/Pebblewyrm.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Pebblewyrm:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public Pebblewyrm()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             PebblewyrmAttack
         };
@@ -30,16 +30,16 @@ public class Pebblewyrm:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> PebblewyrmAttack()
+    public async Task<FamiliarAttackingAction> PebblewyrmAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Pebblewyrm Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class Pebblewyrm:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/Ropopus.cs
+++ b/AFamiliarWorld/Bot/Familiars/Ropopus.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Ropopus:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public Ropopus()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             RopopusAttack
         };
@@ -30,16 +30,16 @@ public class Ropopus:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> RopopusAttack()
+    public async Task<FamiliarAttackingAction> RopopusAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Ropopus Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class Ropopus:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/SkeleMouse.cs
+++ b/AFamiliarWorld/Bot/Familiars/SkeleMouse.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class SkeleMouse:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public SkeleMouse()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             SkeleMouseAttack
         };
@@ -30,16 +30,16 @@ public class SkeleMouse:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> SkeleMouseAttack()
+    public async Task<FamiliarAttackingAction> SkeleMouseAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "SkeleMouse Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class SkeleMouse:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/SlimeCat.cs
+++ b/AFamiliarWorld/Bot/Familiars/SlimeCat.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class SlimeCat:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public SlimeCat()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             SlimeCatAttack
         };
@@ -30,16 +30,16 @@ public class SlimeCat:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> SlimeCatAttack()
+    public async Task<FamiliarAttackingAction> SlimeCatAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "SlimeCat Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class SlimeCat:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/StarRaven.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarRaven.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class StarRaven:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public StarRaven()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             StarRavenAttack
         };
@@ -30,16 +30,16 @@ public class StarRaven:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> StarRavenAttack()
+    public async Task<FamiliarAttackingAction> StarRavenAttack()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "StarRaven Attack";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class StarRaven:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/CrystalBeetle.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/CrystalBeetle.cs
@@ -5,11 +5,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class CrystalBeetle:Familiar
 {
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 40;
     public CrystalBeetle()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             BeetleBonk,
             Slam
@@ -33,17 +33,17 @@ public class CrystalBeetle:Familiar
         this.Cuteness = Math.Min(random.Next(1, 10001), random.Next(1, 10001));
     }
     
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
 
-    public async Task<FamiliarAction> BeetleBonk()
+    public async Task<FamiliarAttackingAction> BeetleBonk()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Beetle Bonk";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -55,9 +55,9 @@ public class CrystalBeetle:Familiar
         return action;
     }
 
-    public async Task<FamiliarAction> Slam()
+    public async Task<FamiliarAttackingAction> Slam()
     {
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Slam";
         action.Damage = 1;
         action.DamageType = DamageType.Physical;
@@ -65,29 +65,30 @@ public class CrystalBeetle:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
 
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/Imp.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/Imp.cs
@@ -1,21 +1,21 @@
 using AFamiliarWorld.Bot.Commands.Models;
 
-namespace AFamiliarWorld.Bot.Familiars;
+namespace AFamiliarWorld.Bot.Familiars.StarterFamiliars;
 
 public class Imp:Familiar
 {
     private int MaxHealth = 40;
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     public Imp()
     {
-        
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             Fireball,
             Scratch,
             Sting,
             WingFlap
         };
+        
         var random = new Random();
         this.Name = "Imp";
         this.Description = "Hehe grumble grumble";
@@ -35,9 +35,9 @@ public class Imp:Familiar
         this.Cuteness = random.Next(1, 10001);
     }
 
-    public async Task<FamiliarAction> WingFlap()
+    public async Task<FamiliarAttackingAction> WingFlap()
     {
-        var action = new FamiliarAction()
+        var action = new FamiliarAttackingAction()
         {
             AbilityName = "Wing flap",
             Damage = 0,
@@ -50,11 +50,11 @@ public class Imp:Familiar
         return action;
     }
 
-    public async Task<FamiliarAction> Sting()
+    public async Task<FamiliarAttackingAction> Sting()
     {
         var random = new Random();
         var crit = random.Next(1, 101) < this.Luck;
-        var action = new FamiliarAction()
+        var action = new FamiliarAttackingAction()
         {
             AbilityName = "Sting",
             Damage = crit ? 4:2,
@@ -65,10 +65,10 @@ public class Imp:Familiar
         return action;
     }
     
-    public async Task<FamiliarAction> Fireball()
+    public async Task<FamiliarAttackingAction> Fireball()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Imp Firebol";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -85,10 +85,10 @@ public class Imp:Familiar
         return action;
     }
     
-    public async Task<FamiliarAction> Scratch()
+    public async Task<FamiliarAttackingAction> Scratch()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Imp Scratch";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -99,35 +99,37 @@ public class Imp:Familiar
         action.DamageType = DamageType.Physical;
         return action;
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/PaperCraneGolem.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/PaperCraneGolem.cs
@@ -5,10 +5,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 public class PaperCraneGolem:Familiar
 {
     private int MaxHealth = 40;
-    private List<Func<Task<FamiliarAction>>> actions;
+    private List<Func<Task<FamiliarAttackingAction>>> actions;
     public PaperCraneGolem()
     {
-        this.actions = new List<Func<Task<FamiliarAction>>>
+        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
         {
             PaperCranePunch
         };
@@ -30,16 +30,16 @@ public class PaperCraneGolem:Familiar
         this.Speed = 1;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack()
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
         return await randomAbility.Invoke();
     }
-    public async Task<FamiliarAction> PaperCranePunch()
+    public async Task<FamiliarAttackingAction> PaperCranePunch()
     {
         var random = new Random();
-        var action = new FamiliarAction();
+        var action = new FamiliarAttackingAction();
         action.AbilityName = "Paper Crane Punch";
         int crit = random.Next(1, 101) < Luck ? 2 : 1;
         if (crit == 2)
@@ -51,28 +51,30 @@ public class PaperCraneGolem:Familiar
         return action;
     }
 
-    public override async Task<int> Defend(FamiliarAction action)
+    public override async Task<FamiliarDefendingAction> Defend(FamiliarAttackingAction attackingAction)
     {
-        if (action.StatusConditions != null)
+        if (attackingAction.StatusConditions != null)
         {
-            foreach (var statusCondition in action.StatusConditions)
+            foreach (var statusCondition in attackingAction.StatusConditions)
             {
                 await this.AddStatusCondition(statusCondition);
             }
         }
-        int damage = -100;
-        if (action.DamageType == DamageType.Physical)
+
+        var defendingAction = new FamiliarDefendingAction()
         {
-            damage = action.Damage - Physique;
-        }
-        else if (action.DamageType == DamageType.Magical)
+            
+        };
+        
+        if (attackingAction.DamageType == DamageType.Physical)
         {
-            damage = (action.Damage - Resolve);
+            defendingAction.DamageTaken = attackingAction.Damage - Physique;
         }
-        if (damage < 1)
+        else if (attackingAction.DamageType == DamageType.Magical)
         {
-            damage = 1;
+            defendingAction.DamageTaken = (attackingAction.Damage - Resolve);
         }
-        return damage;
+        
+        return defendingAction;
     }
 }

--- a/AFamiliarWorld/Bot/Player/Player.cs
+++ b/AFamiliarWorld/Bot/Player/Player.cs
@@ -1,4 +1,5 @@
 using AFamiliarWorld.Bot.Familiars;
+using AFamiliarWorld.Bot.Familiars.StarterFamiliars;
 
 namespace AFamiliarWorld.Bot.Player;
 


### PR DESCRIPTION
Rarther than returning an int, Familiar#Defend should return an object that allows us to implement reflected damage, as well as type and what caused it, this will allow for better control over what happens to a defending familiar
