### PR TITLE
refactor:Familiars Attackers should take in the defenders as an arg

### DIFF
--- a/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
+++ b/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
@@ -164,16 +164,15 @@ public class FamiliarBattles
                 }
                 else
                 {
-                    var attack = await attacker.Attack();
+                    var attack = await attacker.Attack(defender);
                     var defend = await defender.Defend(attack);
                     defender.Health -= defend.DamageTaken;
 
-                    var criticalHit = attack.CriticalHit == true ? "***" : "";
-                    
-                    await UpdateImage(firstAttacker, secondAttacker,
-                        $"{criticalHit}{attackerUser.Username}'s {attacker.Name} attacks using {attack.AbilityName} for {defend.DamageTaken} damage!{criticalHit}",
-                        pvpImage);
-
+                    var criticalHit = attack.CriticalHit ? "***" : "";
+                    var output = attack.CustomOutput ?? $"{criticalHit}{attackerUser.Username}'s {attacker.Name} attacks using {attack.AbilityName} for {defend.DamageTaken} damage!{criticalHit}";
+                
+                    await UpdateImage(firstAttacker, secondAttacker, output, pvpImage);
+            
 
                     var winner = await CheckWinner(firstAttacker, secondAttacker, attacker, attackerUser, defender, defenderUser, pvpImage);
                     if (winner)

--- a/AFamiliarWorld/Bot/Commands/Models/FamiliarAttackingAction.cs
+++ b/AFamiliarWorld/Bot/Commands/Models/FamiliarAttackingAction.cs
@@ -8,4 +8,5 @@ public class FamiliarAttackingAction
     public bool CriticalHit { get; set; } = false;
     public List<StatusCondition>? StatusConditions { get; set; }
     public bool IsTrueDamage { get; set; } = false;
+    public string? CustomOutput { get; set; } = null;
 }

--- a/AFamiliarWorld/Bot/Familiars/Bandcoon.cs
+++ b/AFamiliarWorld/Bot/Familiars/Bandcoon.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Bandcoon:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public Bandcoon()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             Moneysack,
             Eattrash,
@@ -41,13 +41,13 @@ public class Bandcoon:Familiar
         this.Abilities.Add(new Ability("Spell: Wash food", $"Washes its food and attacks them. Deals {this.Power}+1d20 damage and removes a random status condition from itself."));
     }
     
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> Moneysack()
+    public async Task<FamiliarAttackingAction> Moneysack(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -116,7 +116,7 @@ public class Bandcoon:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> Eattrash()
+    public async Task<FamiliarAttackingAction> Eattrash(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -128,30 +128,38 @@ public class Bandcoon:Familiar
         switch (option)
         {
             case 0:
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 10 Power!";
                 this.Power += 10;
                 break;
             case 1:
                 this.Physique += 10;
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 10 Physique!";
                 break;
             case 2:
                 this.Willpower += 10;
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 10 Willpower!";
                 break;
             case 3:
                 this.Resolve += 10;
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 10 Resolve!";
                 break;
             case 4:
                 this.Luck += 5;
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 5 Luck!";
                 break;
             case 5:
                 this.Speed += 10;
+                action.CustomOutput = $"Bandcoon uses {action.AbilityName} and gains 10 Speed!";
                 break;
             case 6:
                 if ((await this.GetStatusConditions()).Contains(StatusCondition.Bleed))
                 {
+                    action.CustomOutput = $"Bandcoon uses {action.AbilityName} and heals 25 HP!";
                     this.Health += 25;
                 }
                 else
                 {
+                    action.CustomOutput = $"Bandcoon uses {action.AbilityName} and heals 50 HP!";
                     this.Health += 50;
                 }
 
@@ -163,7 +171,7 @@ public class Bandcoon:Familiar
         
         return action;
     }
-    public async Task<FamiliarAttackingAction> Pistolwhip()
+    public async Task<FamiliarAttackingAction> Pistolwhip(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -180,13 +188,13 @@ public class Bandcoon:Familiar
         {
             this.Health -= 50;
             action.Damage = 0;
-            action.AbilityName += " (and hits itself instead for 50 damage)";
+            action.CustomOutput = "Bandcoon tries to pistol whip, but accidentally hits itself instead for 50 damage!";
         }
         
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Washfood()
+    public async Task<FamiliarAttackingAction> Washfood(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/Batnana.cs
+++ b/AFamiliarWorld/Bot/Familiars/Batnana.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Batnana:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     private bool isEvading = false;
     public Batnana()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             Monch,
             EvasiveFlutter,
@@ -43,13 +43,13 @@ public class Batnana:Familiar
         this.Abilities.Add(new Ability("Spell: FruitfulShriek", $"A physical attack that deals 10 true damage and stuns the target."));
         this.Abilities.Add(new Ability("Spell: Scritchies", $"A physical attack that deals 20 true damage and causes the target to bleed."));
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> Monch()
+    public async Task<FamiliarAttackingAction> Monch(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -70,7 +70,7 @@ public class Batnana:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> EvasiveFlutter()
+    public async Task<FamiliarAttackingAction> EvasiveFlutter(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -81,7 +81,7 @@ public class Batnana:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> PotassiumSurge()
+    public async Task<FamiliarAttackingAction> PotassiumSurge(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -93,7 +93,7 @@ public class Batnana:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> FruitfulShriek()
+    public async Task<FamiliarAttackingAction> FruitfulShriek(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -105,7 +105,7 @@ public class Batnana:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> Scritchies()
+    public async Task<FamiliarAttackingAction> Scritchies(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/BookMimic.cs
+++ b/AFamiliarWorld/Bot/Familiars/BookMimic.cs
@@ -4,11 +4,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class BookMimic:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     private int MaxHealth = 300;
     public BookMimic()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             BookBite
         };
@@ -33,14 +33,14 @@ public class BookMimic:Familiar
         this.Speed = 5;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
     
-    public async Task<FamiliarAttackingAction> BookBite()
+    public async Task<FamiliarAttackingAction> BookBite(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/Clockroach.cs
+++ b/AFamiliarWorld/Bot/Familiars/Clockroach.cs
@@ -6,11 +6,11 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Clockroach : Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     private int RewindHealth = 225;
     public Clockroach()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             GearjammerBite,
             Timespark,
@@ -41,14 +41,14 @@ public class Clockroach : Familiar
         this.Cuteness = random.Next(1, 10001);
     }
 
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
 
-    public async Task<FamiliarAttackingAction> GearjammerBite()
+    public async Task<FamiliarAttackingAction> GearjammerBite(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -64,7 +64,7 @@ public class Clockroach : Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Timespark()
+    public async Task<FamiliarAttackingAction> Timespark(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -80,7 +80,7 @@ public class Clockroach : Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Flickerstrike()
+    public async Task<FamiliarAttackingAction> Flickerstrike(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -96,7 +96,7 @@ public class Clockroach : Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Selfdestruct()
+    public async Task<FamiliarAttackingAction> Selfdestruct(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -112,7 +112,7 @@ public class Clockroach : Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> SelfRewind()
+    public async Task<FamiliarAttackingAction> SelfRewind(Familiar familiar)
     {
         var action = new FamiliarAttackingAction()
         

--- a/AFamiliarWorld/Bot/Familiars/Familiar.cs
+++ b/AFamiliarWorld/Bot/Familiars/Familiar.cs
@@ -144,7 +144,7 @@ public class Familiar
         return embed.Build();
     }
 
-    public virtual async Task<FamiliarAttackingAction> Attack()
+    public virtual async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         return null;
     }

--- a/AFamiliarWorld/Bot/Familiars/LandShork.cs
+++ b/AFamiliarWorld/Bot/Familiars/LandShork.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class LandShork:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public LandShork()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             LandShorkMonch
         };
@@ -32,13 +32,13 @@ public class LandShork:Familiar
         this.Speed = 8;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> LandShorkMonch()
+    public async Task<FamiliarAttackingAction> LandShorkMonch(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/NoodleCrab.cs
+++ b/AFamiliarWorld/Bot/Familiars/NoodleCrab.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class NoodleCrab:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public NoodleCrab()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             NoodleCrabPinch
         };
@@ -32,13 +32,13 @@ public class NoodleCrab:Familiar
         this.Speed = 3;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> NoodleCrabPinch()
+    public async Task<FamiliarAttackingAction> NoodleCrabPinch(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/Pebblewyrm.cs
+++ b/AFamiliarWorld/Bot/Familiars/Pebblewyrm.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Pebblewyrm:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public Pebblewyrm()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             PebblewyrmAttack
         };
@@ -32,13 +32,13 @@ public class Pebblewyrm:Familiar
         this.Speed = 9;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> PebblewyrmAttack()
+    public async Task<FamiliarAttackingAction> PebblewyrmAttack(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/Ropopus.cs
+++ b/AFamiliarWorld/Bot/Familiars/Ropopus.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class Ropopus:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public Ropopus()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             RopopusAttack
         };
@@ -32,13 +32,13 @@ public class Ropopus:Familiar
         this.Speed = 6;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> RopopusAttack()
+    public async Task<FamiliarAttackingAction> RopopusAttack(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/SkeleMouse.cs
+++ b/AFamiliarWorld/Bot/Familiars/SkeleMouse.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class SkeleMouse:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public SkeleMouse()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             SkeleMouseAttack
         };
@@ -32,13 +32,13 @@ public class SkeleMouse:Familiar
         this.Speed = 10;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> SkeleMouseAttack()
+    public async Task<FamiliarAttackingAction> SkeleMouseAttack(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/SlimeCat.cs
+++ b/AFamiliarWorld/Bot/Familiars/SlimeCat.cs
@@ -3,11 +3,11 @@ using AFamiliarWorld.Bot.Commands.Models;
 namespace AFamiliarWorld.Bot.Familiars;
 public class SlimeCat:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     private int ambushDamage = 0;
     public SlimeCat()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             PseudopawStrike,
             AcidicLick,
@@ -36,7 +36,7 @@ public class SlimeCat:Familiar
         this.Speed = 2;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var ambush = 0;
         if (this.ambushDamage > 0)
@@ -46,11 +46,11 @@ public class SlimeCat:Familiar
         }
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        var attackingaction = await randomAbility.Invoke();
+        var attackingaction = await randomAbility.Invoke(enemyFamiliar);
         attackingaction.Damage += ambush;
         return attackingaction;
     }
-    public async Task<FamiliarAttackingAction> PseudopawStrike()
+    public async Task<FamiliarAttackingAction> PseudopawStrike(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -65,7 +65,7 @@ public class SlimeCat:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> AcidicLick()
+    public async Task<FamiliarAttackingAction> AcidicLick(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -81,7 +81,7 @@ public class SlimeCat:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Purralysis()
+    public async Task<FamiliarAttackingAction> Purralysis(Familiar familiar)
     {
         var action = new FamiliarAttackingAction();
         action.AbilityName = "Purralysis";
@@ -92,7 +92,7 @@ public class SlimeCat:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> PuddleformAmbush()
+    public async Task<FamiliarAttackingAction> PuddleformAmbush(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -109,7 +109,7 @@ public class SlimeCat:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Licc()
+    public async Task<FamiliarAttackingAction> Licc(Familiar familiar)
     {
         var action = new FamiliarAttackingAction();
         action.AbilityName = "Licc";

--- a/AFamiliarWorld/Bot/Familiars/StarRaven.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarRaven.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class StarRaven:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public StarRaven()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             Peck,
             EnvelopingVoid,
@@ -36,13 +36,13 @@ public class StarRaven:Familiar
         this.Speed = 11;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> Peck()
+    public async Task<FamiliarAttackingAction> Peck(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -58,7 +58,7 @@ public class StarRaven:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> EnvelopingVoid()
+    public async Task<FamiliarAttackingAction> EnvelopingVoid(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -74,7 +74,7 @@ public class StarRaven:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> ColorSpray()
+    public async Task<FamiliarAttackingAction> ColorSpray(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -85,7 +85,7 @@ public class StarRaven:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> Starburn()
+    public async Task<FamiliarAttackingAction> Starburn(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -101,7 +101,7 @@ public class StarRaven:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> GuidingStar()
+    public async Task<FamiliarAttackingAction> GuidingStar(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/CrystalBeetle.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/CrystalBeetle.cs
@@ -5,12 +5,12 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class CrystalBeetle:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     private bool _isHunkeredDown = false;
     private int _shatterPulseDamage = 0;
     public CrystalBeetle()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             BeetleBonk,
             Slam,
@@ -47,7 +47,7 @@ public class CrystalBeetle:Familiar
         this.Abilities.Add(new Ability("Spell: Shatter Pulse", $"A magical attack that deals half of {this.Power}+1d20 physical damage and applies a shatter pulse. The next time you use an attack, it will deal the other half ontop of your regular attack as magical damage."));
     }
     
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var shatterDamage = 0;
         if (this._shatterPulseDamage > 0)
@@ -57,12 +57,12 @@ public class CrystalBeetle:Familiar
         }
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        var attackingaction = await randomAbility.Invoke();
+        var attackingaction = await randomAbility.Invoke(enemyFamiliar);
         attackingaction.Damage += shatterDamage;
         return attackingaction;
     }
 
-    public async Task<FamiliarAttackingAction> BeetleBonk()
+    public async Task<FamiliarAttackingAction> BeetleBonk(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -77,7 +77,7 @@ public class CrystalBeetle:Familiar
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Slam()
+    public async Task<FamiliarAttackingAction> Slam(Familiar familiar)
     {
         var action = new FamiliarAttackingAction();
         action.AbilityName = "Slam";
@@ -88,17 +88,18 @@ public class CrystalBeetle:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> HunkerDown()
+    public async Task<FamiliarAttackingAction> HunkerDown(Familiar familiar)
     {
         var action = new FamiliarAttackingAction();
         action.AbilityName = "Hunker down";
         action.Damage = 0;
+        action.CustomOutput = "The Crystal Beetle hunkers down, reducing incoming damage by its Willpower for the next attack";
         action.DamageType = DamageType.Physical;
         action.IsTrueDamage = true;
         this._isHunkeredDown = true;
         return action;
     }
-    public async Task<FamiliarAttackingAction> ShatterPulse()
+    public async Task<FamiliarAttackingAction> ShatterPulse(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -116,7 +117,7 @@ public class CrystalBeetle:Familiar
         
         return action;
     }
-    public async Task<FamiliarAttackingAction> PrismaticSpark()
+    public async Task<FamiliarAttackingAction> PrismaticSpark(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/Imp.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/Imp.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars.StarterFamiliars;
 
 public class Imp:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public Imp()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             Firebolt,
             Scratch,
@@ -42,7 +42,7 @@ public class Imp:Familiar
         this.Abilities.Add(new Ability("Spell: Wing Flap", $"A magical attack that deals 0 damage and clears all status conditions, transferring them to the target."));
     }
 
-    public async Task<FamiliarAttackingAction> WingFlap()
+    public async Task<FamiliarAttackingAction> WingFlap(Familiar familiar)
     {
         var action = new FamiliarAttackingAction()
         {
@@ -51,14 +51,15 @@ public class Imp:Familiar
             CriticalHit = false,
             DamageType = DamageType.Magical,
             StatusConditions = (await this.GetStatusConditions()).ToList(),
-            IsTrueDamage = true
+            IsTrueDamage = true,
+            CustomOutput = $"{this.Name} flaps its wings, transferring its status conditions"
         };
 
         await this.ClearStatusConditions();
         return action;
     }
 
-    public async Task<FamiliarAttackingAction> Sting()
+    public async Task<FamiliarAttackingAction> Sting(Familiar familiar)
     {
         var random = new Random();
         var crit = random.Next(1, 101) < this.Luck;
@@ -74,7 +75,7 @@ public class Imp:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> Firebolt()
+    public async Task<FamiliarAttackingAction> Firebolt(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -94,7 +95,7 @@ public class Imp:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> Scratch()
+    public async Task<FamiliarAttackingAction> Scratch(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -108,10 +109,10 @@ public class Imp:Familiar
         action.DamageType = DamageType.Physical;
         return action;
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
 }

--- a/AFamiliarWorld/Bot/Familiars/StarterFamiliars/PaperCraneGolem.cs
+++ b/AFamiliarWorld/Bot/Familiars/StarterFamiliars/PaperCraneGolem.cs
@@ -4,10 +4,10 @@ namespace AFamiliarWorld.Bot.Familiars;
 
 public class PaperCraneGolem:Familiar
 {
-    private List<Func<Task<FamiliarAttackingAction>>> actions;
+    private List<Func<Familiar, Task<FamiliarAttackingAction>>> actions;
     public PaperCraneGolem()
     {
-        this.actions = new List<Func<Task<FamiliarAttackingAction>>>
+        this.actions = new List<Func<Familiar, Task<FamiliarAttackingAction>>>
         {
             PapercutBarrage,
             GuillotineFold,
@@ -34,13 +34,13 @@ public class PaperCraneGolem:Familiar
         this.Speed = 7;
         this.Cuteness = random.Next(1, 10001);
     }
-    public override async Task<FamiliarAttackingAction> Attack()
+    public override async Task<FamiliarAttackingAction> Attack(Familiar enemyFamiliar)
     {
         var random = new Random();
         var randomAbility = actions[random.Next(actions.Count)];
-        return await randomAbility.Invoke();
+        return await randomAbility.Invoke(enemyFamiliar);
     }
-    public async Task<FamiliarAttackingAction> PapercutBarrage()
+    public async Task<FamiliarAttackingAction> PapercutBarrage(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -55,7 +55,7 @@ public class PaperCraneGolem:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> GuillotineFold()
+    public async Task<FamiliarAttackingAction> GuillotineFold(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();
@@ -66,7 +66,7 @@ public class PaperCraneGolem:Familiar
         return action;
     }
     
-    public async Task<FamiliarAttackingAction> ConfettiBurst()
+    public async Task<FamiliarAttackingAction> ConfettiBurst(Familiar familiar)
     {
         var random = new Random();
         var action = new FamiliarAttackingAction();


### PR DESCRIPTION
The attackers should take in the defenders as an arg to allow them to have direct control over the stats of the other familiar, this will be used for stat reductions only, everything else should be done through the FamiliarAttackingAction to allow the FamiliarBattler to have direct control over the battle