### PR TITLE
fix:PvPImage should run in parallel

### DIFF
--- a/AFamiliarWorld/Bot/BattleGenerator/BattleImage.cs
+++ b/AFamiliarWorld/Bot/BattleGenerator/BattleImage.cs
@@ -1,0 +1,7 @@
+﻿namespace AFamiliarWorld.Bot.BattleGenerator;
+
+public class BattleImage
+{
+    public MemoryStream ImageStream { get; set; }
+    public int Index { get; set; }
+}

--- a/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
+++ b/AFamiliarWorld/Bot/Commands/FamiliarBattles.cs
@@ -36,7 +36,7 @@ public class FamiliarBattles
                 }
                 
                 await ReplyAsync($"{user.Username} accepted the challenge!");
-
+                await Context.Channel.TriggerTypingAsync();
                 var pvpImage = new PvPImage();
                 var winner = await Dual(Context, user, pvpImage);
                 if (winner == null) return;

--- a/AFamiliarWorld/Bot/Familiars/Familiar.cs
+++ b/AFamiliarWorld/Bot/Familiars/Familiar.cs
@@ -50,6 +50,7 @@ public class Familiar
     {
         FamiliarID = Guid.NewGuid().ToString();
     }
+
     public async Task<List<Ability>> GetAbilities()
     {
         return Abilities;


### PR DESCRIPTION
At the moment, each frame of the animation is rendered async, this commit fixes that by running them as tasks, assigning an index for the frames, and then compiling the frames once they're all drawn